### PR TITLE
Minor Objective-C syntax modernization

### DIFF
--- a/Source/PBJVideoPlayerController.m
+++ b/Source/PBJVideoPlayerController.m
@@ -465,7 +465,7 @@ typedef void (^PBJVideoPlayerBlock)();
             }
         }
         
-        AVPlayerStatus status = [[change objectForKey:NSKeyValueChangeNewKey] integerValue];
+        AVPlayerStatus status = [change[NSKeyValueChangeNewKey] integerValue];
         switch (status)
         {
             case AVPlayerStatusReadyToPlay:

--- a/Source/PBJVideoView.m
+++ b/Source/PBJVideoView.m
@@ -71,7 +71,7 @@
 
 #pragma mark - init
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {


### PR DESCRIPTION
Use instancetype rather than id. Use literal dictionary syntax.
