### PR TITLE
restructuring and ability to mute audio

### DIFF
--- a/Source/PBJVideoPlayer.h
+++ b/Source/PBJVideoPlayer.h
@@ -55,6 +55,7 @@ typedef NS_ENUM(NSInteger, PBJVideoPlayerBufferingState) {
 @property (nonatomic, readonly) PBJVideoPlayerBufferingState bufferingState;
 
 @property (nonatomic, readonly) NSTimeInterval maxDuration;
+@property (nonatomic) BOOL muted;
 
 - (void)playFromBeginning;
 - (void)playFromCurrentTime;

--- a/Source/PBJVideoPlayer.h
+++ b/Source/PBJVideoPlayer.h
@@ -1,0 +1,74 @@
+//
+//  PBJVideoPlayerController.h
+//
+//  Created by Patrick Piemonte on 5/27/13.
+//  Copyright (c) 2013-present, Patrick Piemonte, http://patrickpiemonte.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+#import "PBJVideoView.h"
+
+typedef NS_ENUM(NSInteger, PBJVideoPlayerPlaybackState) {
+    PBJVideoPlayerPlaybackStateStopped = 0,
+    PBJVideoPlayerPlaybackStatePlaying,
+    PBJVideoPlayerPlaybackStatePaused,
+    PBJVideoPlayerPlaybackStateFailed,
+};
+
+typedef NS_ENUM(NSInteger, PBJVideoPlayerBufferingState) {
+    PBJVideoPlayerBufferingStateUnknown = 0,
+    PBJVideoPlayerBufferingStateReady,
+    PBJVideoPlayerBufferingStateDelayed,
+};
+
+// PBJVideoPlayerController.view provides the interface for playing/streaming videos
+@protocol PBJVideoPlayerDelegate;
+
+@interface PBJVideoPlayer : NSObject
+
+@property (nonatomic, weak) id<PBJVideoPlayerDelegate> delegate;
+
+@property (nonatomic, copy) NSString *videoPath;
+@property (nonatomic, copy) NSString *videoFillMode; // default, AVLayerVideoGravityResizeAspect
+@property (nonatomic, readonly) PBJVideoView * videoView;
+
+@property (nonatomic) BOOL playbackLoops;
+@property (nonatomic) BOOL playbackFreezesAtEnd;
+@property (nonatomic, readonly) PBJVideoPlayerPlaybackState playbackState;
+@property (nonatomic, readonly) PBJVideoPlayerBufferingState bufferingState;
+
+@property (nonatomic, readonly) NSTimeInterval maxDuration;
+
+- (void)playFromBeginning;
+- (void)playFromCurrentTime;
+- (void)pause;
+- (void)stop;
+
+@end
+
+@protocol PBJVideoPlayerDelegate <NSObject>
+@required
+- (void)videoPlayerReady:(PBJVideoPlayer *)videoPlayer;
+- (void)videoPlayerPlaybackStateDidChange:(PBJVideoPlayer *)videoPlayer;
+
+- (void)videoPlayerPlaybackWillStartFromBeginning:(PBJVideoPlayer *)videoPlayer;
+- (void)videoPlayerPlaybackDidEnd:(PBJVideoPlayer *)videoPlayer;
+
+@end

--- a/Source/PBJVideoPlayer.h
+++ b/Source/PBJVideoPlayer.h
@@ -40,12 +40,18 @@ typedef NS_ENUM(NSInteger, PBJVideoPlayerBufferingState) {
 
 // PBJVideoPlayerController.view provides the interface for playing/streaming videos
 @protocol PBJVideoPlayerDelegate;
+@class AVAsset;
 
 @interface PBJVideoPlayer : NSObject
 
 @property (nonatomic, weak) id<PBJVideoPlayerDelegate> delegate;
 
+// if you want to set the AVAsset manually, you can do so here
+@property (nonatomic) AVAsset *asset;
+
+// if you'd rather specify a path to your video than create an AVAsset, set videoPath
 @property (nonatomic, copy) NSString *videoPath;
+
 @property (nonatomic, copy) NSString *videoFillMode; // default, AVLayerVideoGravityResizeAspect
 @property (nonatomic, readonly) PBJVideoView * videoView;
 

--- a/Source/PBJVideoPlayer.h
+++ b/Source/PBJVideoPlayer.h
@@ -55,7 +55,11 @@ typedef NS_ENUM(NSInteger, PBJVideoPlayerBufferingState) {
 @property (nonatomic, readonly) PBJVideoPlayerBufferingState bufferingState;
 
 @property (nonatomic, readonly) NSTimeInterval maxDuration;
+// set to YES to mute audio
 @property (nonatomic) BOOL muted;
+
+// set the number of times to try reloading the video
+@property (nonatomic) unsigned int retries;
 
 - (void)playFromBeginning;
 - (void)playFromCurrentTime;

--- a/Source/PBJVideoPlayer.m
+++ b/Source/PBJVideoPlayer.m
@@ -236,6 +236,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
             }
 
             // setup player
+            [self _videoPlayerAudioSessionActive:NO]; // the next line causes the audio mode to change, so we need to update it here in addition to when we play
             AVPlayerItem *playerItem = [AVPlayerItem playerItemWithAsset:_asset];
             [self _setPlayerItem:playerItem];
             

--- a/Source/PBJVideoPlayer.m
+++ b/Source/PBJVideoPlayer.m
@@ -61,7 +61,6 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
 
 @interface PBJVideoPlayer ()
 {
-    AVAsset *_asset;
     AVPlayer *_player;
     AVPlayerItem *_playerItem;
 
@@ -135,7 +134,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     _videoPath = [videoPath copy];
 
     AVURLAsset *asset = [AVURLAsset URLAssetWithURL:videoURL options:nil];
-    [self _setAsset:asset];
+    [self setAsset:asset];
 }
 
 - (BOOL)playbackLoops
@@ -187,7 +186,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     _player.muted = muted;
 }
 
-- (void)_setAsset:(AVAsset *)asset
+- (void)setAsset:(AVAsset *)asset
 {
     if (_asset == asset)
         return;

--- a/Source/PBJVideoPlayer.m
+++ b/Source/PBJVideoPlayer.m
@@ -1,0 +1,458 @@
+//
+//  PBJVideoPlayerController.m
+//
+//  Created by Patrick Piemonte on 5/27/13.
+//  Copyright (c) 2013-present, Patrick Piemonte, http://patrickpiemonte.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import "PBJVideoPlayerController.h"
+#import "PBJVideoView.h"
+
+#import <AVFoundation/AVFoundation.h>
+
+#define LOG_PLAYER 0
+#ifndef DLog
+#if !defined(NDEBUG) && LOG_PLAYER
+#   define DLog(fmt, ...) NSLog((@"player: " fmt), ##__VA_ARGS__);
+#else
+#   define DLog(...)
+#endif
+#endif
+
+// KVO contexts
+static NSString * const PBJVideoPlayerObserverContext = @"PBJVideoPlayerObserverContext";
+static NSString * const PBJVideoPlayerItemObserverContext = @"PBJVideoPlayerItemObserverContext";
+static NSString * const PBJVideoPlayerLayerObserverContext = @"PBJVideoPlayerLayerObserverContext";
+
+// KVO player keys
+static NSString * const PBJVideoPlayerControllerTracksKey = @"tracks";
+static NSString * const PBJVideoPlayerControllerPlayableKey = @"playable";
+static NSString * const PBJVideoPlayerControllerDurationKey = @"duration";
+static NSString * const PBJVideoPlayerControllerRateKey = @"rate";
+
+// KVO player item keys
+static NSString * const PBJVideoPlayerControllerStatusKey = @"status";
+static NSString * const PBJVideoPlayerControllerEmptyBufferKey = @"playbackBufferEmpty";
+static NSString * const PBJVideoPlayerControllerPlayerKeepUpKey = @"playbackLikelyToKeepUp";
+
+// KVO player layer keys
+static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisplay";
+
+// TODO: scrubbing support
+//static float const PBJVideoPlayerControllerRates[PBJVideoPlayerRateCount] = { 0.25, 0.5, 0.75, 1, 1.5, 2 };
+//static NSInteger const PBJVideoPlayerRateCount = 6;
+
+@interface PBJVideoPlayer ()
+{
+    AVAsset *_asset;
+    AVPlayer *_player;
+    AVPlayerItem *_playerItem;
+
+    NSString *_videoPath;
+
+    PBJVideoPlayerPlaybackState _playbackState;
+    PBJVideoPlayerBufferingState _bufferingState;
+    
+    // flags
+    struct {
+        unsigned int playbackLoops:1;
+        unsigned int playbackFreezesAtEnd:1;
+    } __block _flags;
+}
+
+@end
+
+@implementation PBJVideoPlayer
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _player = [[AVPlayer alloc] init];
+        _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
+        
+        // Player KVO
+        [_player addObserver:self forKeyPath:PBJVideoPlayerControllerRateKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerObserverContext)];
+        
+        // load the playerLayer view
+        _videoView = [[PBJVideoView alloc] initWithFrame:CGRectZero];
+        _videoView.videoFillMode = AVLayerVideoGravityResizeAspect;
+        _videoView.playerLayer.hidden = YES;
+        
+        // playerLayer KVO
+        [_videoView.playerLayer addObserver:self forKeyPath:PBJVideoPlayerControllerReadyForDisplay options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerLayerObserverContext)];
+        
+        // Application NSNotifications
+        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+        [nc addObserver:self selector:@selector(_applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
+        [nc addObserver:self selector:@selector(_applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    }
+    
+    return self;
+}
+
+#pragma mark - getters/setters
+
+- (void)setVideoFillMode:(NSString *)videoFillMode
+{
+	if (_videoFillMode != videoFillMode) {
+		_videoFillMode = videoFillMode;
+		_videoView.videoFillMode = _videoFillMode;
+	}
+}
+
+- (NSString *)videoPath
+{
+    return _videoPath;
+}
+
+- (void)setVideoPath:(NSString *)videoPath
+{
+    if (!videoPath || [videoPath length] == 0)
+        return;
+
+    NSURL *videoURL = [NSURL URLWithString:videoPath];
+    if (!videoURL || ![videoURL scheme]) {
+        videoURL = [NSURL fileURLWithPath:videoPath];
+    }
+    _videoPath = [videoPath copy];
+
+    AVURLAsset *asset = [AVURLAsset URLAssetWithURL:videoURL options:nil];
+    [self _setAsset:asset];
+}
+
+- (BOOL)playbackLoops
+{
+    return _flags.playbackLoops;
+}
+
+- (void)setPlaybackLoops:(BOOL)playbackLoops
+{
+    _flags.playbackLoops = (unsigned int)playbackLoops;
+    if (!_player)
+        return;
+    
+    if (!_flags.playbackLoops) {
+        _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
+    } else {
+        _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
+    }
+}
+
+- (BOOL)playbackFreezesAtEnd
+{
+    return _flags.playbackFreezesAtEnd;
+}
+
+- (void)setPlaybackFreezesAtEnd:(BOOL)playbackFreezesAtEnd
+{
+    _flags.playbackFreezesAtEnd = (unsigned int)playbackFreezesAtEnd;
+}
+
+- (NSTimeInterval)maxDuration {
+    NSTimeInterval maxDuration = -1;
+    
+    if (CMTIME_IS_NUMERIC(_playerItem.duration)) {
+        maxDuration = CMTimeGetSeconds(_playerItem.duration);
+    }
+    
+    return maxDuration;
+}
+
+- (void)_setAsset:(AVAsset *)asset
+{
+    if (_asset == asset)
+        return;
+    
+    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying) {
+        [self pause];
+    }
+
+    _bufferingState = PBJVideoPlayerBufferingStateUnknown;
+    _asset = asset;
+
+    if (!_asset) {
+        [self _setPlayerItem:nil];
+    }
+    
+    NSArray *keys = @[PBJVideoPlayerControllerTracksKey, PBJVideoPlayerControllerPlayableKey, PBJVideoPlayerControllerDurationKey];
+    
+    [_asset loadValuesAsynchronouslyForKeys:keys completionHandler:^{
+        [self _enqueueBlockOnMainQueue:^{
+        
+            // check the keys
+            for (NSString *key in keys) {
+                NSError *error = nil;
+                AVKeyValueStatus keyStatus = [asset statusOfValueForKey:key error:&error];
+                if (keyStatus == AVKeyValueStatusFailed) {
+                    _playbackState = PBJVideoPlayerPlaybackStateFailed;
+                    [_delegate videoPlayerPlaybackStateDidChange:self];
+                    return;
+                }
+            }
+
+            // check playable
+            if (!_asset.playable) {
+                _playbackState = PBJVideoPlayerPlaybackStateFailed;
+                [_delegate videoPlayerPlaybackStateDidChange:self];
+                return;
+            }
+
+            // setup player
+            AVPlayerItem *playerItem = [AVPlayerItem playerItemWithAsset:_asset];
+            [self _setPlayerItem:playerItem];
+            
+        }];
+    }];
+}
+
+- (void)_setPlayerItem:(AVPlayerItem *)playerItem
+{
+    if (_playerItem == playerItem)
+        return;
+    
+    // remove observers
+    if (_playerItem) {
+        // AVPlayerItem KVO
+        [_playerItem removeObserver:self forKeyPath:PBJVideoPlayerControllerEmptyBufferKey context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
+        [_playerItem removeObserver:self forKeyPath:PBJVideoPlayerControllerPlayerKeepUpKey context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
+        [_playerItem removeObserver:self forKeyPath:PBJVideoPlayerControllerStatusKey context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
+
+        // notifications
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:_playerItem];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:_playerItem];
+    }
+    
+    _playerItem = playerItem;
+    
+    // add observers
+    if (_playerItem) {
+        // AVPlayerItem KVO
+        [_playerItem addObserver:self forKeyPath:PBJVideoPlayerControllerEmptyBufferKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
+        [_playerItem addObserver:self forKeyPath:PBJVideoPlayerControllerPlayerKeepUpKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
+        [_playerItem addObserver:self forKeyPath:PBJVideoPlayerControllerStatusKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
+        
+        // notifications
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_playerItemDidPlayToEndTime:) name:AVPlayerItemDidPlayToEndTimeNotification object:_playerItem];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_playerItemFailedToPlayToEndTime:) name:AVPlayerItemFailedToPlayToEndTimeNotification object:_playerItem];
+    }
+    
+    if (!_flags.playbackLoops) {
+        _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
+    } else {
+        _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
+    }
+
+    [_player replaceCurrentItemWithPlayerItem:_playerItem];
+}
+
+#pragma mark - init
+
+- (void)dealloc
+{
+    _videoView.player = nil;
+    _delegate = nil;
+
+    // notifications
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    // Layer KVO
+    [_videoView.layer removeObserver:self forKeyPath:PBJVideoPlayerControllerReadyForDisplay context:(__bridge void *)PBJVideoPlayerLayerObserverContext];
+
+    // AVPlayer KVO
+    [_player removeObserver:self forKeyPath:PBJVideoPlayerControllerRateKey context:(__bridge void *)PBJVideoPlayerObserverContext];
+
+    // player
+    [_player pause];
+    
+    // player item
+    [self _setPlayerItem:nil];
+}
+
+#pragma mark - private methods
+
+- (void)_videoPlayerAudioSessionActive:(BOOL)active
+{
+    NSString *category = active ? AVAudioSessionCategoryPlayback : AVAudioSessionCategoryAmbient;
+    
+    NSError *error = nil;
+    [[AVAudioSession sharedInstance] setCategory:category error:&error];
+    if (error) {
+        DLog(@"audio session active error (%@)", error);
+    }
+}
+
+- (void)_updatePlayerRatio
+{
+}
+
+#pragma mark - public methods
+
+- (void)playFromBeginning
+{
+    DLog(@"playing from beginnging...");
+    
+    [_delegate videoPlayerPlaybackWillStartFromBeginning:self];
+    [_player seekToTime:kCMTimeZero];
+    [self playFromCurrentTime];
+}
+
+- (void)playFromCurrentTime
+{
+    DLog(@"playing...");
+    
+    _playbackState = PBJVideoPlayerPlaybackStatePlaying;
+    [_delegate videoPlayerPlaybackStateDidChange:self];
+    [_player play];
+}
+
+- (void)pause
+{
+    if (_playbackState != PBJVideoPlayerPlaybackStatePlaying)
+        return;
+    
+    DLog(@"pause");
+    
+    [_player pause];
+    _playbackState = PBJVideoPlayerPlaybackStatePaused;
+    [_delegate videoPlayerPlaybackStateDidChange:self];
+}
+
+- (void)stop
+{
+    if (_playbackState == PBJVideoPlayerPlaybackStateStopped)
+        return;
+    
+    DLog(@"stop");
+
+    [_player pause];
+    _playbackState = PBJVideoPlayerPlaybackStateStopped;
+    [_delegate videoPlayerPlaybackStateDidChange:self];
+}
+
+#pragma mark - main queue helper
+
+typedef void (^PBJVideoPlayerBlock)();
+
+- (void)_enqueueBlockOnMainQueue:(PBJVideoPlayerBlock)block {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        block();
+    });
+}
+
+#pragma mark - AV NSNotificaions
+
+- (void)_playerItemDidPlayToEndTime:(NSNotification *)aNotification
+{
+    if (_flags.playbackLoops || !_flags.playbackFreezesAtEnd) {
+        [_player seekToTime:kCMTimeZero];
+    }
+    
+    if (!_flags.playbackLoops) {
+        [self stop];
+        [_delegate videoPlayerPlaybackDidEnd:self];
+    }
+}
+
+- (void)_playerItemFailedToPlayToEndTime:(NSNotification *)aNotification
+{
+    _playbackState = PBJVideoPlayerPlaybackStateFailed;
+    [_delegate videoPlayerPlaybackStateDidChange:self];
+    DLog(@"error (%@)", [[aNotification userInfo] objectForKey:AVPlayerItemFailedToPlayToEndTimeErrorKey]);
+}
+
+#pragma mark - App NSNotifications
+
+- (void)_applicationWillResignActive:(NSNotification *)aNotfication
+{
+    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying)
+        [self pause];
+}
+
+- (void)_applicationDidEnterBackground:(NSNotification *)aNotfication
+{
+    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying)
+        [self pause];
+}
+
+#pragma mark - KVO
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if ( context == (__bridge void *)(PBJVideoPlayerObserverContext) ) {
+    
+        // Player KVO
+    
+    } else if ( context == (__bridge void *)(PBJVideoPlayerItemObserverContext) ) {
+        
+        // PlayerItem KVO
+        
+        if ([keyPath isEqualToString:PBJVideoPlayerControllerEmptyBufferKey]) {
+            if (_playerItem.playbackBufferEmpty) {
+                DLog(@"playback buffer is empty");
+            }
+        } else if ([keyPath isEqualToString:PBJVideoPlayerControllerPlayerKeepUpKey]) {
+            if (_playerItem.playbackLikelyToKeepUp) {
+                DLog(@"playback buffer is likely to keep up");
+                if (_playbackState == PBJVideoPlayerPlaybackStatePlaying) {
+                    [self playFromCurrentTime];
+                }
+            }
+        }
+        
+        AVPlayerStatus status = [change[NSKeyValueChangeNewKey] integerValue];
+        switch (status)
+        {
+            case AVPlayerStatusReadyToPlay:
+            {
+                _videoView.playerLayer.backgroundColor = [[UIColor blackColor] CGColor];
+                [_videoView.playerLayer setPlayer:_player];
+                _videoView.playerLayer.hidden = NO;
+                break;
+            }
+            case AVPlayerStatusFailed:
+            {
+                _playbackState = PBJVideoPlayerPlaybackStateFailed;
+                [_delegate videoPlayerPlaybackStateDidChange:self];
+                break;
+            }
+            case AVPlayerStatusUnknown:
+            default:
+                break;
+        }
+
+    } else if ( context == (__bridge void *)(PBJVideoPlayerLayerObserverContext) ) {
+    
+        // PlayerLayer KVO
+        
+        if ([keyPath isEqualToString:PBJVideoPlayerControllerReadyForDisplay]) {
+            if (_videoView.playerLayer.readyForDisplay) {
+                [_delegate videoPlayerReady:self];
+            }
+        }
+    
+    } else {
+    
+		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+	
+    }
+}
+
+@end

--- a/Source/PBJVideoPlayer.m
+++ b/Source/PBJVideoPlayer.m
@@ -176,6 +176,17 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     return maxDuration;
 }
 
+- (BOOL)muted
+{
+    return _player.muted;
+}
+
+- (void)setMuted:(BOOL)muted
+{
+    DLog(@"muted: %u", muted);
+    _player.muted = muted;
+}
+
 - (void)_setAsset:(AVAsset *)asset
 {
     if (_asset == asset)

--- a/Source/PBJVideoPlayer.m
+++ b/Source/PBJVideoPlayer.m
@@ -310,7 +310,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
 
 - (void)_videoPlayerAudioSessionActive:(BOOL)active
 {
-    NSString *category = active ? AVAudioSessionCategoryPlayback : AVAudioSessionCategoryAmbient;
+    NSString *category = (active && !self.muted) ? AVAudioSessionCategoryPlayback : AVAudioSessionCategoryAmbient;
     
     NSError *error = nil;
     [[AVAudioSession sharedInstance] setCategory:category error:&error];
@@ -339,6 +339,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     DLog(@"playing...");
     
     _playbackState = PBJVideoPlayerPlaybackStatePlaying;
+    [self _videoPlayerAudioSessionActive:YES];
     [_delegate videoPlayerPlaybackStateDidChange:self];
     [_player play];
 }
@@ -352,6 +353,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     
     [_player pause];
     _playbackState = PBJVideoPlayerPlaybackStatePaused;
+    [self _videoPlayerAudioSessionActive:NO];
     [_delegate videoPlayerPlaybackStateDidChange:self];
 }
 
@@ -364,6 +366,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
 
     [_player pause];
     _playbackState = PBJVideoPlayerPlaybackStateStopped;
+    [self _videoPlayerAudioSessionActive:NO];
     [_delegate videoPlayerPlaybackStateDidChange:self];
 }
 

--- a/Source/PBJVideoPlayerController.h
+++ b/Source/PBJVideoPlayerController.h
@@ -24,48 +24,10 @@
 
 #import <UIKit/UIKit.h>
 
-typedef NS_ENUM(NSInteger, PBJVideoPlayerPlaybackState) {
-    PBJVideoPlayerPlaybackStateStopped = 0,
-    PBJVideoPlayerPlaybackStatePlaying,
-    PBJVideoPlayerPlaybackStatePaused,
-    PBJVideoPlayerPlaybackStateFailed,
-};
+#import "PBJVideoPlayer.h"
 
-typedef NS_ENUM(NSInteger, PBJVideoPlayerBufferingState) {
-    PBJVideoPlayerBufferingStateUnknown = 0,
-    PBJVideoPlayerBufferingStateReady,
-    PBJVideoPlayerBufferingStateDelayed,
-};
-
-// PBJVideoPlayerController.view provides the interface for playing/streaming videos
-@protocol PBJVideoPlayerControllerDelegate;
 @interface PBJVideoPlayerController : UIViewController
 
-@property (nonatomic, weak) id<PBJVideoPlayerControllerDelegate> delegate;
-
-@property (nonatomic, copy) NSString *videoPath;
-@property (nonatomic, copy) NSString *videoFillMode; // default, AVLayerVideoGravityResizeAspect
-
-@property (nonatomic) BOOL playbackLoops;
-@property (nonatomic) BOOL playbackFreezesAtEnd;
-@property (nonatomic, readonly) PBJVideoPlayerPlaybackState playbackState;
-@property (nonatomic, readonly) PBJVideoPlayerBufferingState bufferingState;
-
-@property (nonatomic, readonly) NSTimeInterval maxDuration;
-
-- (void)playFromBeginning;
-- (void)playFromCurrentTime;
-- (void)pause;
-- (void)stop;
-
-@end
-
-@protocol PBJVideoPlayerControllerDelegate <NSObject>
-@required
-- (void)videoPlayerReady:(PBJVideoPlayerController *)videoPlayer;
-- (void)videoPlayerPlaybackStateDidChange:(PBJVideoPlayerController *)videoPlayer;
-
-- (void)videoPlayerPlaybackWillStartFromBeginning:(PBJVideoPlayerController *)videoPlayer;
-- (void)videoPlayerPlaybackDidEnd:(PBJVideoPlayerController *)videoPlayer;
+@property (nonatomic) PBJVideoPlayer* player;
 
 @end

--- a/Source/PBJVideoPlayerController.m
+++ b/Source/PBJVideoPlayerController.m
@@ -25,374 +25,59 @@
 #import "PBJVideoPlayerController.h"
 #import "PBJVideoView.h"
 
-#import <AVFoundation/AVFoundation.h>
-
-#define LOG_PLAYER 0
-#ifndef DLog
-#if !defined(NDEBUG) && LOG_PLAYER
-#   define DLog(fmt, ...) NSLog((@"player: " fmt), ##__VA_ARGS__);
-#else
-#   define DLog(...)
-#endif
-#endif
-
-// KVO contexts
-static NSString * const PBJVideoPlayerObserverContext = @"PBJVideoPlayerObserverContext";
-static NSString * const PBJVideoPlayerItemObserverContext = @"PBJVideoPlayerItemObserverContext";
-static NSString * const PBJVideoPlayerLayerObserverContext = @"PBJVideoPlayerLayerObserverContext";
-
-// KVO player keys
-static NSString * const PBJVideoPlayerControllerTracksKey = @"tracks";
-static NSString * const PBJVideoPlayerControllerPlayableKey = @"playable";
-static NSString * const PBJVideoPlayerControllerDurationKey = @"duration";
-static NSString * const PBJVideoPlayerControllerRateKey = @"rate";
-
-// KVO player item keys
-static NSString * const PBJVideoPlayerControllerStatusKey = @"status";
-static NSString * const PBJVideoPlayerControllerEmptyBufferKey = @"playbackBufferEmpty";
-static NSString * const PBJVideoPlayerControllerPlayerKeepUpKey = @"playbackLikelyToKeepUp";
-
-// KVO player layer keys
-static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisplay";
-
-// TODO: scrubbing support
-//static float const PBJVideoPlayerControllerRates[PBJVideoPlayerRateCount] = { 0.25, 0.5, 0.75, 1, 1.5, 2 };
-//static NSInteger const PBJVideoPlayerRateCount = 6;
-
 @interface PBJVideoPlayerController () <
     UIGestureRecognizerDelegate>
 {
-    AVAsset *_asset;
-    AVPlayer *_player;
-    AVPlayerItem *_playerItem;
-
-    NSString *_videoPath;
-    PBJVideoView *_videoView;
-
-    PBJVideoPlayerPlaybackState _playbackState;
-    PBJVideoPlayerBufferingState _bufferingState;
-    
-    // flags
-    struct {
-        unsigned int playbackLoops:1;
-        unsigned int playbackFreezesAtEnd:1;
-    } __block _flags;
 }
 
 @end
 
 @implementation PBJVideoPlayerController
 
-@synthesize delegate = _delegate;
-@synthesize videoPath = _videoPath;
-@synthesize playbackState = _playbackState;
-@synthesize bufferingState = _bufferingState;
-@synthesize videoFillMode = _videoFillMode;
-
-#pragma mark - getters/setters
-
-- (void)setVideoFillMode:(NSString *)videoFillMode
-{
-	if (_videoFillMode != videoFillMode) {
-		_videoFillMode = videoFillMode;
-		_videoView.videoFillMode = _videoFillMode;
-	}
-}
-
-- (NSString *)videoPath
-{
-    return _videoPath;
-}
-
-- (void)setVideoPath:(NSString *)videoPath
-{
-    if (!videoPath || [videoPath length] == 0)
-        return;
-
-    NSURL *videoURL = [NSURL URLWithString:videoPath];
-    if (!videoURL || ![videoURL scheme]) {
-        videoURL = [NSURL fileURLWithPath:videoPath];
-    }
-    _videoPath = [videoPath copy];
-
-    AVURLAsset *asset = [AVURLAsset URLAssetWithURL:videoURL options:nil];
-    [self _setAsset:asset];
-}
-
-- (BOOL)playbackLoops
-{
-    return _flags.playbackLoops;
-}
-
-- (void)setPlaybackLoops:(BOOL)playbackLoops
-{
-    _flags.playbackLoops = (unsigned int)playbackLoops;
-    if (!_player)
-        return;
-    
-    if (!_flags.playbackLoops) {
-        _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
-    } else {
-        _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
-    }
-}
-
-- (BOOL)playbackFreezesAtEnd
-{
-    return _flags.playbackFreezesAtEnd;
-}
-
-- (void)setPlaybackFreezesAtEnd:(BOOL)playbackFreezesAtEnd
-{
-    _flags.playbackFreezesAtEnd = (unsigned int)playbackFreezesAtEnd;
-}
-
-- (NSTimeInterval)maxDuration {
-    NSTimeInterval maxDuration = -1;
-    
-    if (CMTIME_IS_NUMERIC(_playerItem.duration)) {
-        maxDuration = CMTimeGetSeconds(_playerItem.duration);
-    }
-    
-    return maxDuration;
-}
-
-- (void)_setAsset:(AVAsset *)asset
-{
-    if (_asset == asset)
-        return;
-    
-    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying) {
-        [self pause];
-    }
-
-    _bufferingState = PBJVideoPlayerBufferingStateUnknown;
-    _asset = asset;
-
-    if (!_asset) {
-        [self _setPlayerItem:nil];
-    }
-    
-    NSArray *keys = @[PBJVideoPlayerControllerTracksKey, PBJVideoPlayerControllerPlayableKey, PBJVideoPlayerControllerDurationKey];
-    
-    [_asset loadValuesAsynchronouslyForKeys:keys completionHandler:^{
-        [self _enqueueBlockOnMainQueue:^{
-        
-            // check the keys
-            for (NSString *key in keys) {
-                NSError *error = nil;
-                AVKeyValueStatus keyStatus = [asset statusOfValueForKey:key error:&error];
-                if (keyStatus == AVKeyValueStatusFailed) {
-                    _playbackState = PBJVideoPlayerPlaybackStateFailed;
-                    [_delegate videoPlayerPlaybackStateDidChange:self];
-                    return;
-                }
-            }
-
-            // check playable
-            if (!_asset.playable) {
-                _playbackState = PBJVideoPlayerPlaybackStateFailed;
-                [_delegate videoPlayerPlaybackStateDidChange:self];
-                return;
-            }
-
-            // setup player
-            AVPlayerItem *playerItem = [AVPlayerItem playerItemWithAsset:_asset];
-            [self _setPlayerItem:playerItem];
-            
-        }];
-    }];
-}
-
-- (void)_setPlayerItem:(AVPlayerItem *)playerItem
-{
-    if (_playerItem == playerItem)
-        return;
-    
-    // remove observers
-    if (_playerItem) {
-        // AVPlayerItem KVO
-        [_playerItem removeObserver:self forKeyPath:PBJVideoPlayerControllerEmptyBufferKey context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
-        [_playerItem removeObserver:self forKeyPath:PBJVideoPlayerControllerPlayerKeepUpKey context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
-        [_playerItem removeObserver:self forKeyPath:PBJVideoPlayerControllerStatusKey context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
-
-        // notifications
-        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:_playerItem];
-        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:_playerItem];
-    }
-    
-    _playerItem = playerItem;
-    
-    // add observers
-    if (_playerItem) {
-        // AVPlayerItem KVO
-        [_playerItem addObserver:self forKeyPath:PBJVideoPlayerControllerEmptyBufferKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
-        [_playerItem addObserver:self forKeyPath:PBJVideoPlayerControllerPlayerKeepUpKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
-        [_playerItem addObserver:self forKeyPath:PBJVideoPlayerControllerStatusKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerItemObserverContext)];
-        
-        // notifications
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_playerItemDidPlayToEndTime:) name:AVPlayerItemDidPlayToEndTimeNotification object:_playerItem];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_playerItemFailedToPlayToEndTime:) name:AVPlayerItemFailedToPlayToEndTimeNotification object:_playerItem];
-    }
-    
-    if (!_flags.playbackLoops) {
-        _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
-    } else {
-        _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
-    }
-
-    [_player replaceCurrentItemWithPlayerItem:_playerItem];
-}
-
 #pragma mark - init
 
 - (void)dealloc
 {
-    _videoView.player = nil;
-    _delegate = nil;
-
-    // notifications
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-
-    // Layer KVO
-    [_videoView.layer removeObserver:self forKeyPath:PBJVideoPlayerControllerReadyForDisplay context:(__bridge void *)PBJVideoPlayerLayerObserverContext];
-
-    // AVPlayer KVO
-    [_player removeObserver:self forKeyPath:PBJVideoPlayerControllerRateKey context:(__bridge void *)PBJVideoPlayerObserverContext];
-
-    // player
-    [_player pause];
-    
-    // player item
-    [self _setPlayerItem:nil];
+    _player = nil;
 }
 
 #pragma mark - view lifecycle
 
 - (void)loadView
 {
-    _player = [[AVPlayer alloc] init];
-    _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
-
-    // Player KVO
-    [_player addObserver:self forKeyPath:PBJVideoPlayerControllerRateKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerObserverContext)];
-
-    // load the playerLayer view
-    _videoView = [[PBJVideoView alloc] initWithFrame:CGRectZero];
-    _videoView.videoFillMode = AVLayerVideoGravityResizeAspect;
-    _videoView.playerLayer.hidden = YES;
-    self.view = _videoView;
-
-    // playerLayer KVO
-    [_videoView.playerLayer addObserver:self forKeyPath:PBJVideoPlayerControllerReadyForDisplay options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerLayerObserverContext)];
-    
-    // Application NSNotifications
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];        
-    [nc addObserver:self selector:@selector(_applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
-    [nc addObserver:self selector:@selector(_applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    self.view = _player.videoView;
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
     
-    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying)
-        [self pause];
-}
-
-#pragma mark - private methods
-
-- (void)_videoPlayerAudioSessionActive:(BOOL)active
-{
-    NSString *category = active ? AVAudioSessionCategoryPlayback : AVAudioSessionCategoryAmbient;
-    
-    NSError *error = nil;
-    [[AVAudioSession sharedInstance] setCategory:category error:&error];
-    if (error) {
-        DLog(@"audio session active error (%@)", error);
-    }
-}
-
-- (void)_updatePlayerRatio
-{
-}
-
-#pragma mark - public methods
-
-- (void)playFromBeginning
-{
-    DLog(@"playing from beginnging...");
-    
-    [_delegate videoPlayerPlaybackWillStartFromBeginning:self];
-    [_player seekToTime:kCMTimeZero];
-    [self playFromCurrentTime];
-}
-
-- (void)playFromCurrentTime
-{
-    DLog(@"playing...");
-    
-    _playbackState = PBJVideoPlayerPlaybackStatePlaying;
-    [_delegate videoPlayerPlaybackStateDidChange:self];
-    [_player play];
-}
-
-- (void)pause
-{
-    if (_playbackState != PBJVideoPlayerPlaybackStatePlaying)
-        return;
-    
-    DLog(@"pause");
-    
-    [_player pause];
-    _playbackState = PBJVideoPlayerPlaybackStatePaused;
-    [_delegate videoPlayerPlaybackStateDidChange:self];
-}
-
-- (void)stop
-{
-    if (_playbackState == PBJVideoPlayerPlaybackStateStopped)
-        return;
-    
-    DLog(@"stop");
-
-    [_player pause];
-    _playbackState = PBJVideoPlayerPlaybackStateStopped;
-    [_delegate videoPlayerPlaybackStateDidChange:self];
-}
-
-#pragma mark - main queue helper
-
-typedef void (^PBJVideoPlayerBlock)();
-
-- (void)_enqueueBlockOnMainQueue:(PBJVideoPlayerBlock)block {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        block();
-    });
+    if (_player.playbackState == PBJVideoPlayerPlaybackStatePlaying)
+        [_player pause];
 }
 
 #pragma mark - UIResponder
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if (_videoPath) {
+    if (_player.videoPath) {
         
-        switch (_playbackState) {
+        switch (_player.playbackState) {
             case PBJVideoPlayerPlaybackStateStopped:
             {
-                [self playFromBeginning];
+                [_player playFromBeginning];
                 break;
             }
             case PBJVideoPlayerPlaybackStatePaused:
             {
-                [self playFromCurrentTime];
+                [_player playFromCurrentTime];
                 break;
             }
             case PBJVideoPlayerPlaybackStatePlaying:
             case PBJVideoPlayerPlaybackStateFailed:
             default:
             {
-                [self pause];
+                [_player pause];
                 break;
             }
         }
@@ -405,110 +90,12 @@ typedef void (^PBJVideoPlayerBlock)();
 
 - (void)_handleTap:(UIGestureRecognizer *)gestureRecognizer
 {
-    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying) {
-        [self pause];
-    } else if (_playbackState == PBJVideoPlayerPlaybackStateStopped) {
-        [self playFromBeginning];
+    if (_player.playbackState == PBJVideoPlayerPlaybackStatePlaying) {
+        [_player pause];
+    } else if (_player.playbackState == PBJVideoPlayerPlaybackStateStopped) {
+        [_player playFromBeginning];
     } else {
-        [self playFromCurrentTime];
-    }
-}
-
-#pragma mark - AV NSNotificaions
-
-- (void)_playerItemDidPlayToEndTime:(NSNotification *)aNotification
-{
-    if (_flags.playbackLoops || !_flags.playbackFreezesAtEnd) {
-        [_player seekToTime:kCMTimeZero];
-    }
-    
-    if (!_flags.playbackLoops) {
-        [self stop];
-        [_delegate videoPlayerPlaybackDidEnd:self];
-    }
-}
-
-- (void)_playerItemFailedToPlayToEndTime:(NSNotification *)aNotification
-{
-    _playbackState = PBJVideoPlayerPlaybackStateFailed;
-    [_delegate videoPlayerPlaybackStateDidChange:self];
-    DLog(@"error (%@)", [[aNotification userInfo] objectForKey:AVPlayerItemFailedToPlayToEndTimeErrorKey]);
-}
-
-#pragma mark - App NSNotifications
-
-- (void)_applicationWillResignActive:(NSNotification *)aNotfication
-{
-    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying)
-        [self pause];
-}
-
-- (void)_applicationDidEnterBackground:(NSNotification *)aNotfication
-{
-    if (_playbackState == PBJVideoPlayerPlaybackStatePlaying)
-        [self pause];
-}
-
-#pragma mark - KVO
-
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
-{
-    if ( context == (__bridge void *)(PBJVideoPlayerObserverContext) ) {
-    
-        // Player KVO
-    
-    } else if ( context == (__bridge void *)(PBJVideoPlayerItemObserverContext) ) {
-        
-        // PlayerItem KVO
-        
-        if ([keyPath isEqualToString:PBJVideoPlayerControllerEmptyBufferKey]) {
-            if (_playerItem.playbackBufferEmpty) {
-                DLog(@"playback buffer is empty");
-            }
-        } else if ([keyPath isEqualToString:PBJVideoPlayerControllerPlayerKeepUpKey]) {
-            if (_playerItem.playbackLikelyToKeepUp) {
-                DLog(@"playback buffer is likely to keep up");
-                if (_playbackState == PBJVideoPlayerPlaybackStatePlaying) {
-                    [self playFromCurrentTime];
-                }
-            }
-        }
-        
-        AVPlayerStatus status = [change[NSKeyValueChangeNewKey] integerValue];
-        switch (status)
-        {
-            case AVPlayerStatusReadyToPlay:
-            {
-                _videoView.playerLayer.backgroundColor = [[UIColor blackColor] CGColor];
-                [_videoView.playerLayer setPlayer:_player];
-                _videoView.playerLayer.hidden = NO;
-                break;
-            }
-            case AVPlayerStatusFailed:
-            {
-                _playbackState = PBJVideoPlayerPlaybackStateFailed;
-                [_delegate videoPlayerPlaybackStateDidChange:self];
-                break;
-            }
-            case AVPlayerStatusUnknown:
-            default:
-                break;
-        }
-
-    } else if ( context == (__bridge void *)(PBJVideoPlayerLayerObserverContext) ) {
-    
-        // PlayerLayer KVO
-        
-        if ([keyPath isEqualToString:PBJVideoPlayerControllerReadyForDisplay]) {
-            if (_videoView.playerLayer.readyForDisplay) {
-                [_delegate videoPlayerReady:self];
-            }
-        }
-    
-    } else {
-    
-		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-	
+        [_player playFromCurrentTime];
     }
 }
 


### PR DESCRIPTION
Hi,
In my app, I needed a video player that wasn't also a UIViewController, so I took the liberty of extracting the video player functionality from your view controller class into a separate class.  I'm fairly certain the full functionality is still present, but it's changed the API quite a bit because the view controller is now just a wrapper around the player.  I'd love to see these changes make their way back into your repository, but I can imagine you won't want to break backwards compatibility.  I just thought I'd open the discussion to see what you think, and if you want, I can try to make it more backwards compatible (it should be possible to be 100% backwards compatible with some work).  If you are willing to break backwards compatibility, I think porting old code to this new interface will be very straightforward and quick.

Additionally, I've included the ability to mute the player audio.

Thanks,
Ryan
