### PR TITLE
Added a `volume` property

### DIFF
--- a/Source/PBJVideoPlayerController.h
+++ b/Source/PBJVideoPlayerController.h
@@ -53,6 +53,8 @@ typedef NS_ENUM(NSInteger, PBJVideoPlayerBufferingState) {
 
 @property (nonatomic, readonly) NSTimeInterval maxDuration;
 
+@property (nonatomic) float volume;
+
 - (void)playFromBeginning;
 - (void)playFromCurrentTime;
 - (void)pause;

--- a/Source/PBJVideoPlayerController.m
+++ b/Source/PBJVideoPlayerController.m
@@ -77,6 +77,8 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
         unsigned int playbackLoops:1;
         unsigned int playbackFreezesAtEnd:1;
     } __block _flags;
+    
+    float _volume;
 }
 
 @end
@@ -162,6 +164,11 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
 }
 
 - (void)setVolume:(float)volume {
+    _volume = volume;
+    
+    if (!_player) {
+        return;
+    }
     _player.volume = volume;
 }
 
@@ -285,7 +292,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
 {
     _player = [[AVPlayer alloc] init];
     _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
-    _player.volume = self.volume;
+    _player.volume = _volume;
 
     // Player KVO
     [_player addObserver:self forKeyPath:PBJVideoPlayerControllerRateKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerObserverContext)];

--- a/Source/PBJVideoPlayerController.m
+++ b/Source/PBJVideoPlayerController.m
@@ -157,6 +157,14 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     return maxDuration;
 }
 
+- (float)volume {
+    return _player.volume;
+}
+
+- (void)setVolume:(float)volume {
+    _player.volume = volume;
+}
+
 - (void)_setAsset:(AVAsset *)asset
 {
     if (_asset == asset)

--- a/Source/PBJVideoPlayerController.m
+++ b/Source/PBJVideoPlayerController.m
@@ -169,6 +169,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
     if (!_player) {
         return;
     }
+    
     _player.volume = volume;
 }
 

--- a/Source/PBJVideoPlayerController.m
+++ b/Source/PBJVideoPlayerController.m
@@ -285,6 +285,7 @@ static NSString * const PBJVideoPlayerControllerReadyForDisplay = @"readyForDisp
 {
     _player = [[AVPlayer alloc] init];
     _player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
+    _player.volume = self.volume;
 
     // Player KVO
     [_player addObserver:self forKeyPath:PBJVideoPlayerControllerRateKey options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld) context:(__bridge void *)(PBJVideoPlayerObserverContext)];


### PR DESCRIPTION
I see that there is a pending PR which adds a `muted` property, but in my specific case, it was better to have a `volume` property.